### PR TITLE
Connection support MySql database

### DIFF
--- a/Connection/Command.cs
+++ b/Connection/Command.cs
@@ -5,16 +5,33 @@ namespace DevHopTools.Connection
 {
     public class Command
     {
+        /// <summary>
+        /// The SQL Query or the stored procedure's name
+        /// </summary>
         internal string Query { get; private set; }
+
+        /// <summary>
+        /// Boolean declaration if this <see cref="Command"/> is a Stored Procedure or not
+        /// </summary>
         internal bool IsStoredProcedure { get; private set; }
+
+        /// <summary>
+        /// Dictionnary with key of type <see cref="string"/> and value of type <see cref="Parameter"/>
+        /// </summary>
         internal IDictionary<string, Parameter> Parameters { get; private set; }
 
+        /// <summary>
+        /// Retrieve the Parameter based on its name
+        /// </summary>
+        /// <param name="parameterName">The parameter name from <see cref="Parameters"/></param>
+        /// <returns>A <see cref="Parameter"/> object from <see cref="Parameters"/> dictionnary</returns>
+        /// <exception cref="InvalidOperationException"></exception>
         public object this[string parameterName]
         {
             get
             {
                 if (!Parameters.ContainsKey(parameterName))
-                    throw new InvalidOperationException("the key does not exist!");
+                    throw new InvalidOperationException($"The parameter \"{parameterName}\" does not exist!");
 
                 //if(Parameters[parameterName].Direction == Direction.Input)
                 //    throw new InvalidOperationException("the direction is Input, there no change after call the procedure!");
@@ -23,6 +40,14 @@ namespace DevHopTools.Connection
             }
         }
 
+        /// <summary>
+        /// Create an instance of <see cref="Command"/> object
+        /// </summary>
+        /// <param name="query">The SQL Query or stored procedure's name.</param>
+        /// <param name="isStoredProcedure">
+        /// true If <paramref name="query"/> is a stored procedure. false Otherwise.
+        /// </param>
+        /// <exception cref="ArgumentException"></exception>
         public Command(string query, bool isStoredProcedure = false)
         {
             if (string.IsNullOrWhiteSpace(query))
@@ -33,11 +58,24 @@ namespace DevHopTools.Connection
             Parameters = new Dictionary<string, Parameter>();
         }
 
+        /// <summary>
+        /// Add a parameter with it's key and value in the <see cref="Parameters"/> dictionnary
+        /// </summary>
+        /// <param name="parameterName">Parameter's name for the query</param>
+        /// <param name="value">Parameter's value for the query</param>
         public void AddParameter(string parameterName, object value)
         {
             AddParameter(parameterName, value, Direction.Input);
         }
 
+        /// <summary>
+        /// Add a parameter with it's key, its value and the direction
+        /// </summary>
+        /// <param name="parameterName">Parameter key</param>
+        /// <param name="value">Parameter's value</param>
+        /// <param name="direction">SQL direction. It query is not stored procedure and direction is output,
+        /// an exception is thrown.</param>
+        /// <exception cref="ArgumentException"></exception>
         public void AddParameter(string parameterName, object value, Direction direction)
         {
             if (string.IsNullOrWhiteSpace(parameterName))

--- a/Connection/Connection.cs
+++ b/Connection/Connection.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using MySqlConnector;
+using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Data.Common;
@@ -7,10 +8,31 @@ namespace DevHopTools.Connection
 {
     public class Connection
     {
+        /// <summary>
+        /// The connection string to the database
+        /// </summary>
         private readonly string _connectionString;
+
+        /// <summary>
+        /// TODO : Comment correctly this property
+        /// </summary>
         private readonly DbProviderFactory _providerFactory;
 
-        public Connection(string connectionString, DbProviderFactory providerFactory)
+        /// <summary>
+        /// Specify which type of database is used
+        /// </summary>
+        private readonly DbType _dbType;
+
+        /// <summary>
+        /// Create an instance of the <see cref="Connection"/> taking the <paramref name="connectionString"/>,
+        /// <paramref name="providerFactory"/> and <paramref name="dbType"/>
+        /// </summary>
+        /// <param name="connectionString">The complete connection string with all needed parameters</param>
+        /// <param name="providerFactory">The database provider factory</param>
+        /// <param name="dbType">The database type used</param>
+        /// <exception cref="ArgumentException"></exception>
+        /// <exception cref="InvalidOperationException"></exception>
+        public Connection(string connectionString, DbProviderFactory providerFactory, DbType dbType)
         {
             if (providerFactory is null)
                 throw new ArgumentException("providerFactory is not valid !");
@@ -20,13 +42,29 @@ namespace DevHopTools.Connection
 
             _connectionString = connectionString;
             _providerFactory = providerFactory;
+            _dbType = dbType;
 
             try
             {
-                using (DbConnection dbConnection = CreateConnection())
+                switch (_dbType)
                 {
-                    dbConnection.Open();
+                    case DbType.MSSQL:
+                        using (DbConnection dbConnection = CreateSqlConnection())
+                        {
+                            dbConnection.Open();
+                        }
+                        break;
+                    case DbType.MySQL:
+                        using (MySqlConnection mySqlConnection = MySql.CreateConnection(_connectionString, _providerFactory))
+                        {
+                            mySqlConnection.Open();
+                        }
+                        break;
+                    default:
+                        throw new InvalidOperationException($"The given database type is not in the list!");
                 }
+
+
             }
             catch (Exception)
             {
@@ -34,104 +72,11 @@ namespace DevHopTools.Connection
             }
         }
 
-        public int ExecuteNonQuery(Command command)
-        {
-            using (DbConnection dbConnection = CreateConnection())
-            {
-                using (DbCommand dbCommand = CreateCommand(command, dbConnection))
-                {
-                    dbConnection.Open();
-                    int rows = dbCommand.ExecuteNonQuery();
-
-                    if (command.IsStoredProcedure)
-                        FinalizeQuery(command, dbCommand);
-
-                    return rows;
-                }
-            }
-        }
-
-        public IEnumerable<TResult> ExecuteReader<TResult>(Command command, Func<IDataRecord, TResult> selector)
-        {
-            using (DbConnection dbConnection = CreateConnection())
-            {
-                using (DbCommand dbCommand = CreateCommand(command, dbConnection))
-                {
-                    dbConnection.Open();
-                    using (DbDataReader dataReader = dbCommand.ExecuteReader())
-                    {
-                        while (dataReader.Read())
-                        {
-                            yield return selector(dataReader);
-                        }
-                    }
-
-                    if (command.IsStoredProcedure)
-                        FinalizeQuery(command, dbCommand);
-                }
-            }
-        }
-
-        public object ExecuteScalar(Command command)
-        {
-            using (DbConnection dbConnection = CreateConnection())
-            {
-                using (DbCommand dbCommand = CreateCommand(command, dbConnection))
-                {
-                    dbConnection.Open();
-                    object result = dbCommand.ExecuteScalar();
-
-                    if (command.IsStoredProcedure)
-                        FinalizeQuery(command, dbCommand);
-
-                    return result is DBNull ? null : result;
-                }
-            }
-        }
-
-        public DataTable GetDataTable(Command command)
-        {
-            using (DbConnection dbConnection = CreateConnection())
-            {
-                using (DbCommand dbCommand = CreateCommand(command, dbConnection))
-                {
-                    using (DbDataAdapter dbDataAdapter = _providerFactory.CreateDataAdapter())
-                    {
-                        DataTable dataTable = new DataTable();
-                        dbDataAdapter.SelectCommand = dbCommand;
-                        dbDataAdapter.Fill(dataTable);
-
-                        if (command.IsStoredProcedure)
-                            FinalizeQuery(command, dbCommand);
-
-                        return dataTable;
-                    }
-                }
-            }
-        }
-
-        public DataSet GetDataSet(Command command)
-        {
-            using (DbConnection dbConnection = CreateConnection())
-            {
-                using (DbCommand dbCommand = CreateCommand(command, dbConnection))
-                {
-                    using (DbDataAdapter dbDataAdapter = _providerFactory.CreateDataAdapter())
-                    {
-                        DataSet dataSet = new DataSet();
-                        dbDataAdapter.SelectCommand = dbCommand;
-                        dbDataAdapter.Fill(dataSet);
-
-                        if (command.IsStoredProcedure)
-                            FinalizeQuery(command, dbCommand);
-
-                        return dataSet;
-                    }
-                }
-            }
-        }
-
-        private DbConnection CreateConnection()
+        /// <summary>
+        /// Create an instance of a configured <see cref="DbConnection"/>
+        /// </summary>
+        /// <returns>A initialized <see cref="DbConnection"/> object with its connection string</returns>
+        private DbConnection CreateSqlConnection()
         {
             DbConnection dbConnection = _providerFactory.CreateConnection();
             dbConnection.ConnectionString = _connectionString;
@@ -139,7 +84,25 @@ namespace DevHopTools.Connection
             return dbConnection;
         }
 
-        private static DbCommand CreateCommand(Command command, DbConnection dbConnection)
+        /// <summary>
+        /// Create an instance of configured <see cref="MySql"/>
+        /// </summary>
+        /// <returns>A initialized <see cref="MySql"/> object with its connection string</returns>
+        private MySql CreateMySqlConnection()
+        {
+            MySql mySqlConnection = (MySql)_providerFactory.CreateConnection();
+            mySqlConnection.ConnectionString = _connectionString;
+
+            return mySqlConnection;
+        }
+
+        /// <summary>
+        /// Create an instance of <see cref="DbCommand"/> 
+        /// </summary>
+        /// <param name="command"></param>
+        /// <param name="dbConnection"></param>
+        /// <returns>A new instance of initialized <see cref="DbCommand"/> object</returns>
+        private static DbCommand CreateSqlCommand(Command command, DbConnection dbConnection)
         {
             DbCommand dbCommand = dbConnection.CreateCommand();
             dbCommand.CommandText = command.Query;
@@ -160,6 +123,177 @@ namespace DevHopTools.Connection
             }
 
             return dbCommand;
+        }
+
+        /// <summary>
+        /// Execute a query and returns the number of row affected
+        /// </summary>
+        /// <param name="command"></param>
+        /// <returns>The number of row affected</returns>
+        /// <exception cref="InvalidOperationException"></exception>
+        public int ExecuteNonQuery(Command command)
+        {
+            switch (_dbType)
+            {
+                case DbType.MSSQL: return ExecuteNonQuery(command);
+                case DbType.MySQL: return ExecuteMySqlNonQuery(command);
+                default:
+                    throw new InvalidOperationException($"Provided database type is not valid!");
+            }
+        }
+
+        /// <summary>
+        /// Execute a query and returns the number of row affected for MSSQL database type
+        /// </summary>
+        /// <param name="command">An object of type <see cref="Command"/> with the desired query</param>
+        /// <returns>The number of rows affected</returns>
+        private int ExecuteSqlNonQuery(Command command)
+        {
+            using (DbConnection dbConnection = CreateSqlConnection())
+            {
+                using (DbCommand dbCommand = CreateSqlCommand(command, dbConnection))
+                {
+                    dbConnection.Open();
+                    int rows = dbCommand.ExecuteNonQuery();
+
+                    if (command.IsStoredProcedure)
+                        FinalizeQuery(command, dbCommand);
+
+                    return rows;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Execute a query and retrieve selected fields values from the database
+        /// </summary>
+        /// <typeparam name="TResult">The type of the object with want to retrieve</typeparam>
+        /// <param name="command">The SQL Command</param>
+        /// <param name="selector">Callback function to map the values from database to the desired type</param>
+        /// <returns>A <see cref="IEnumerable{T}"/> of type <typeparamref name="TResult"/></returns>
+        public IEnumerable<TResult> ExecuteReader<TResult>(Command command, Func<IDataRecord, TResult> selector)
+        {
+            switch (_dbType)
+            {
+                case DbType.MSSQL: return ExecuteSqlReader(command, selector);
+                case DbType.MySQL: return ExecuteMySqlReader(command, selector);
+                default:
+                    throw new InvalidOperationException($"Provided database type is not valid!");
+            }
+        }
+
+        /// <summary>
+        /// Execute a query and retrieve selected fields values from a Microsoft SQL Database
+        /// </summary>
+        /// <typeparam name="TResult">The type of the object with want to retrieve</typeparam>
+        /// <param name="command">The SQL Command</param>
+        /// <param name="selector">Callback function to map the values from database to the desired type</param>
+        /// <returns>A <see cref="IEnumerable{T}"/> of type <typeparamref name="TResult"/></returns>
+        private IEnumerable<TResult> ExecuteSqlReader<TResult>(Command command, Func<IDataRecord, TResult> selector)
+        {
+            using (DbConnection dbConnection = CreateSqlConnection())
+            {
+                using (DbCommand dbCommand = CreateSqlCommand(command, dbConnection))
+                {
+                    dbConnection.Open();
+                    using (DbDataReader dataReader = dbCommand.ExecuteReader())
+                    {
+                        while (dataReader.Read())
+                        {
+                            yield return selector(dataReader);
+                        }
+                    }
+
+                    if (command.IsStoredProcedure)
+                        FinalizeQuery(command, dbCommand);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Execute query and retrieve only one data
+        /// </summary>
+        /// <param name="command"></param>
+        /// <returns>The desired unique object from database</returns>
+        public object ExecuteScalar(Command command)
+        {
+            using (DbConnection dbConnection = CreateSqlConnection())
+            {
+                using (DbCommand dbCommand = CreateSqlCommand(command, dbConnection))
+                {
+                    dbConnection.Open();
+                    object result = dbCommand.ExecuteScalar();
+
+                    if (command.IsStoredProcedure)
+                        FinalizeQuery(command, dbCommand);
+
+                    return result is DBNull ? null : result;
+                }
+            }
+        }
+
+        /// <summary>
+        /// The private method of <see cref="ExecuteScalar(Command)"/> for Microsoft SQL databases
+        /// </summary>
+        /// <param name="command"></param>
+        /// <returns></returns>
+        private object ExecuteSqlScalar(Command command)
+        {
+            using (DbConnection dbConnection = CreateSqlConnection())
+            {
+                using (DbCommand dbCommand = CreateSqlCommand(command, dbConnection))
+                {
+                    dbConnection.Open();
+                    object result = dbCommand.ExecuteScalar();
+
+                    if (command.IsStoredProcedure)
+                        FinalizeQuery(command, dbCommand);
+
+                    return result is DBNull ? null : result;
+                }
+            }
+        }
+
+        public DataTable GetDataTable(Command command)
+        {
+            using (DbConnection dbConnection = CreateSqlConnection())
+            {
+                using (DbCommand dbCommand = CreateSqlCommand(command, dbConnection))
+                {
+                    using (DbDataAdapter dbDataAdapter = _providerFactory.CreateDataAdapter())
+                    {
+                        DataTable dataTable = new DataTable();
+                        dbDataAdapter.SelectCommand = dbCommand;
+                        dbDataAdapter.Fill(dataTable);
+
+                        if (command.IsStoredProcedure)
+                            FinalizeQuery(command, dbCommand);
+
+                        return dataTable;
+                    }
+                }
+            }
+        }
+
+        public DataSet GetDataSet(Command command)
+        {
+            using (DbConnection dbConnection = CreateSqlConnection())
+            {
+                using (DbCommand dbCommand = CreateSqlCommand(command, dbConnection))
+                {
+                    using (DbDataAdapter dbDataAdapter = _providerFactory.CreateDataAdapter())
+                    {
+                        DataSet dataSet = new DataSet();
+                        dbDataAdapter.SelectCommand = dbCommand;
+                        dbDataAdapter.Fill(dataSet);
+
+                        if (command.IsStoredProcedure)
+                            FinalizeQuery(command, dbCommand);
+
+                        return dataSet;
+                    }
+                }
+            }
         }
 
         private void FinalizeQuery(Command command, DbCommand dbCommand)

--- a/Connection/Connection.cs
+++ b/Connection/Connection.cs
@@ -49,7 +49,7 @@ namespace DevHopTools.Connection
                 switch (_dbType)
                 {
                     case DbType.MSSQL:
-                        using (DbConnection dbConnection = CreateSqlConnection())
+                        using (DbConnection dbConnection = CreateConnection())
                         {
                             dbConnection.Open();
                         }
@@ -76,7 +76,7 @@ namespace DevHopTools.Connection
         /// Create an instance of a configured <see cref="DbConnection"/>
         /// </summary>
         /// <returns>A initialized <see cref="DbConnection"/> object with its connection string</returns>
-        private DbConnection CreateSqlConnection()
+        private DbConnection CreateConnection()
         {
             DbConnection dbConnection = _providerFactory.CreateConnection();
             dbConnection.ConnectionString = _connectionString;
@@ -137,7 +137,7 @@ namespace DevHopTools.Connection
         /// <returns>The number of rows affected</returns>
         private int ExecuteSqlNonQuery(Command command)
         {
-            using (DbConnection dbConnection = CreateSqlConnection())
+            using (DbConnection dbConnection = CreateConnection())
             {
                 using (DbCommand dbCommand = CreateSqlCommand(command, dbConnection))
                 {
@@ -179,7 +179,7 @@ namespace DevHopTools.Connection
         /// <returns>A <see cref="IEnumerable{T}"/> of type <typeparamref name="TResult"/></returns>
         private IEnumerable<TResult> ExecuteSqlReader<TResult>(Command command, Func<IDataRecord, TResult> selector)
         {
-            using (DbConnection dbConnection = CreateSqlConnection())
+            using (DbConnection dbConnection = CreateConnection())
             {
                 using (DbCommand dbCommand = CreateSqlCommand(command, dbConnection))
                 {
@@ -205,7 +205,7 @@ namespace DevHopTools.Connection
         /// <returns>The desired unique object from database</returns>
         public object ExecuteScalar(Command command)
         {
-            using (DbConnection dbConnection = CreateSqlConnection())
+            using (DbConnection dbConnection = CreateConnection())
             {
                 using (DbCommand dbCommand = CreateSqlCommand(command, dbConnection))
                 {
@@ -227,7 +227,7 @@ namespace DevHopTools.Connection
         /// <returns></returns>
         private object ExecuteSqlScalar(Command command)
         {
-            using (DbConnection dbConnection = CreateSqlConnection())
+            using (DbConnection dbConnection = CreateConnection())
             {
                 using (DbCommand dbCommand = CreateSqlCommand(command, dbConnection))
                 {
@@ -244,7 +244,7 @@ namespace DevHopTools.Connection
 
         public DataTable GetDataTable(Command command)
         {
-            using (DbConnection dbConnection = CreateSqlConnection())
+            using (DbConnection dbConnection = CreateConnection())
             {
                 using (DbCommand dbCommand = CreateSqlCommand(command, dbConnection))
                 {
@@ -265,7 +265,7 @@ namespace DevHopTools.Connection
 
         public DataSet GetDataSet(Command command)
         {
-            using (DbConnection dbConnection = CreateSqlConnection())
+            using (DbConnection dbConnection = CreateConnection())
             {
                 using (DbCommand dbCommand = CreateSqlCommand(command, dbConnection))
                 {

--- a/Connection/Connection.cs
+++ b/Connection/Connection.cs
@@ -85,18 +85,6 @@ namespace DevHopTools.Connection
         }
 
         /// <summary>
-        /// Create an instance of configured <see cref="MySql"/>
-        /// </summary>
-        /// <returns>A initialized <see cref="MySql"/> object with its connection string</returns>
-        private MySql CreateMySqlConnection()
-        {
-            MySql mySqlConnection = (MySql)_providerFactory.CreateConnection();
-            mySqlConnection.ConnectionString = _connectionString;
-
-            return mySqlConnection;
-        }
-
-        /// <summary>
         /// Create an instance of <see cref="DbCommand"/> 
         /// </summary>
         /// <param name="command"></param>
@@ -136,7 +124,7 @@ namespace DevHopTools.Connection
             switch (_dbType)
             {
                 case DbType.MSSQL: return ExecuteNonQuery(command);
-                case DbType.MySQL: return ExecuteMySqlNonQuery(command);
+                case DbType.MySQL: return MySql.ExecuteNonQuery(_connectionString, _providerFactory, command);
                 default:
                     throw new InvalidOperationException($"Provided database type is not valid!");
             }
@@ -176,7 +164,7 @@ namespace DevHopTools.Connection
             switch (_dbType)
             {
                 case DbType.MSSQL: return ExecuteSqlReader(command, selector);
-                case DbType.MySQL: return ExecuteMySqlReader(command, selector);
+                case DbType.MySQL: return MySql.ExecuteReader(_connectionString, _providerFactory, command, selector);
                 default:
                     throw new InvalidOperationException($"Provided database type is not valid!");
             }

--- a/Connection/Connection.cs
+++ b/Connection/Connection.cs
@@ -108,7 +108,7 @@ namespace DevHopTools.Connection
         }
 
         /// <summary>
-        /// Execute query and retrieve only one data
+        /// Execute query and retrieve only one field value
         /// </summary>
         /// <param name="command"></param>
         /// <returns>The desired unique object from database</returns>

--- a/Connection/Connection.cs
+++ b/Connection/Connection.cs
@@ -49,7 +49,7 @@ namespace DevHopTools.Connection
                 switch (_dbType)
                 {
                     case DbType.MSSQL:
-                        using (DbConnection dbConnection = CreateConnection())
+                        using (DbConnection dbConnection = MSSQL.CreateConnection(_connectionString, _providerFactory))
                         {
                             dbConnection.Open();
                         }
@@ -73,47 +73,6 @@ namespace DevHopTools.Connection
         }
 
         /// <summary>
-        /// Create an instance of a configured <see cref="DbConnection"/>
-        /// </summary>
-        /// <returns>A initialized <see cref="DbConnection"/> object with its connection string</returns>
-        private DbConnection CreateConnection()
-        {
-            DbConnection dbConnection = _providerFactory.CreateConnection();
-            dbConnection.ConnectionString = _connectionString;
-
-            return dbConnection;
-        }
-
-        /// <summary>
-        /// Create an instance of <see cref="DbCommand"/> 
-        /// </summary>
-        /// <param name="command"></param>
-        /// <param name="dbConnection"></param>
-        /// <returns>A new instance of initialized <see cref="DbCommand"/> object</returns>
-        private static DbCommand CreateSqlCommand(Command command, DbConnection dbConnection)
-        {
-            DbCommand dbCommand = dbConnection.CreateCommand();
-            dbCommand.CommandText = command.Query;
-
-            if (command.IsStoredProcedure)
-                dbCommand.CommandType = CommandType.StoredProcedure;
-
-            foreach (KeyValuePair<string, Parameter> parameter in command.Parameters)
-            {
-                DbParameter dbParameter = dbCommand.CreateParameter();
-                dbParameter.ParameterName = parameter.Key;
-                dbParameter.Value = parameter.Value.ParameterValue;
-
-                if (parameter.Value.Direction == Direction.Output)
-                    dbParameter.Direction = ParameterDirection.Output;
-
-                dbCommand.Parameters.Add(dbParameter);
-            }
-
-            return dbCommand;
-        }
-
-        /// <summary>
         /// Execute a query and returns the number of row affected
         /// </summary>
         /// <param name="command"></param>
@@ -123,32 +82,10 @@ namespace DevHopTools.Connection
         {
             switch (_dbType)
             {
-                case DbType.MSSQL: return ExecuteNonQuery(command);
+                case DbType.MSSQL: return MSSQL.ExecuteNonQuery(_connectionString, _providerFactory, command);
                 case DbType.MySQL: return MySql.ExecuteNonQuery(_connectionString, _providerFactory, command);
                 default:
                     throw new InvalidOperationException($"Provided database type is not valid!");
-            }
-        }
-
-        /// <summary>
-        /// Execute a query and returns the number of row affected for MSSQL database type
-        /// </summary>
-        /// <param name="command">An object of type <see cref="Command"/> with the desired query</param>
-        /// <returns>The number of rows affected</returns>
-        private int ExecuteSqlNonQuery(Command command)
-        {
-            using (DbConnection dbConnection = CreateConnection())
-            {
-                using (DbCommand dbCommand = CreateSqlCommand(command, dbConnection))
-                {
-                    dbConnection.Open();
-                    int rows = dbCommand.ExecuteNonQuery();
-
-                    if (command.IsStoredProcedure)
-                        FinalizeQuery(command, dbCommand);
-
-                    return rows;
-                }
             }
         }
 
@@ -163,38 +100,10 @@ namespace DevHopTools.Connection
         {
             switch (_dbType)
             {
-                case DbType.MSSQL: return ExecuteSqlReader(command, selector);
+                case DbType.MSSQL: return MSSQL.ExecuteReader(_connectionString, _providerFactory, command, selector);
                 case DbType.MySQL: return MySql.ExecuteReader(_connectionString, _providerFactory, command, selector);
                 default:
                     throw new InvalidOperationException($"Provided database type is not valid!");
-            }
-        }
-
-        /// <summary>
-        /// Execute a query and retrieve selected fields values from a Microsoft SQL Database
-        /// </summary>
-        /// <typeparam name="TResult">The type of the object with want to retrieve</typeparam>
-        /// <param name="command">The SQL Command</param>
-        /// <param name="selector">Callback function to map the values from database to the desired type</param>
-        /// <returns>A <see cref="IEnumerable{T}"/> of type <typeparamref name="TResult"/></returns>
-        private IEnumerable<TResult> ExecuteSqlReader<TResult>(Command command, Func<IDataRecord, TResult> selector)
-        {
-            using (DbConnection dbConnection = CreateConnection())
-            {
-                using (DbCommand dbCommand = CreateSqlCommand(command, dbConnection))
-                {
-                    dbConnection.Open();
-                    using (DbDataReader dataReader = dbCommand.ExecuteReader())
-                    {
-                        while (dataReader.Read())
-                        {
-                            yield return selector(dataReader);
-                        }
-                    }
-
-                    if (command.IsStoredProcedure)
-                        FinalizeQuery(command, dbCommand);
-                }
             }
         }
 
@@ -205,93 +114,36 @@ namespace DevHopTools.Connection
         /// <returns>The desired unique object from database</returns>
         public object ExecuteScalar(Command command)
         {
-            using (DbConnection dbConnection = CreateConnection())
+            switch (_dbType)
             {
-                using (DbCommand dbCommand = CreateSqlCommand(command, dbConnection))
-                {
-                    dbConnection.Open();
-                    object result = dbCommand.ExecuteScalar();
-
-                    if (command.IsStoredProcedure)
-                        FinalizeQuery(command, dbCommand);
-
-                    return result is DBNull ? null : result;
-                }
+                case DbType.MSSQL: return MSSQL.ExecuteScalar(_connectionString, _providerFactory, command);
+                case DbType.MySQL: return MySql.ExecuteScalar(_connectionString, _providerFactory, command);
+                default:
+                    throw new InvalidOperationException($"Provided database type is not valid!");
             }
         }
 
-        /// <summary>
-        /// The private method of <see cref="ExecuteScalar(Command)"/> for Microsoft SQL databases
-        /// </summary>
-        /// <param name="command"></param>
-        /// <returns></returns>
-        private object ExecuteSqlScalar(Command command)
-        {
-            using (DbConnection dbConnection = CreateConnection())
-            {
-                using (DbCommand dbCommand = CreateSqlCommand(command, dbConnection))
-                {
-                    dbConnection.Open();
-                    object result = dbCommand.ExecuteScalar();
-
-                    if (command.IsStoredProcedure)
-                        FinalizeQuery(command, dbCommand);
-
-                    return result is DBNull ? null : result;
-                }
-            }
-        }
-
+        // TODO : Write a good complete comment
         public DataTable GetDataTable(Command command)
         {
-            using (DbConnection dbConnection = CreateConnection())
+            switch (_dbType)
             {
-                using (DbCommand dbCommand = CreateSqlCommand(command, dbConnection))
-                {
-                    using (DbDataAdapter dbDataAdapter = _providerFactory.CreateDataAdapter())
-                    {
-                        DataTable dataTable = new DataTable();
-                        dbDataAdapter.SelectCommand = dbCommand;
-                        dbDataAdapter.Fill(dataTable);
-
-                        if (command.IsStoredProcedure)
-                            FinalizeQuery(command, dbCommand);
-
-                        return dataTable;
-                    }
-                }
+                case DbType.MSSQL: return MSSQL.GetDataTable(_connectionString, _providerFactory, command);
+                case DbType.MySQL: return MySql.GetDataTable(_connectionString, _providerFactory, command);
+                default:
+                    throw new InvalidOperationException($"Provided database type is not valid!");
             }
         }
 
+        // TODO : Write a good complete comment
         public DataSet GetDataSet(Command command)
         {
-            using (DbConnection dbConnection = CreateConnection())
+            switch (_dbType)
             {
-                using (DbCommand dbCommand = CreateSqlCommand(command, dbConnection))
-                {
-                    using (DbDataAdapter dbDataAdapter = _providerFactory.CreateDataAdapter())
-                    {
-                        DataSet dataSet = new DataSet();
-                        dbDataAdapter.SelectCommand = dbCommand;
-                        dbDataAdapter.Fill(dataSet);
-
-                        if (command.IsStoredProcedure)
-                            FinalizeQuery(command, dbCommand);
-
-                        return dataSet;
-                    }
-                }
-            }
-        }
-
-        private void FinalizeQuery(Command command, DbCommand dbCommand)
-        {
-            foreach (KeyValuePair<string, Parameter> parameter in command.Parameters)
-            {
-                if (parameter.Value.Direction == Direction.Output)
-                {
-                    parameter.Value.ParameterValue = dbCommand.Parameters[parameter.Key].Value;
-                }
+                case DbType.MSSQL: return MSSQL.GetDataSet(_connectionString, _providerFactory, command);
+                case DbType.MySQL: return MySql.GetDataSet(_connectionString, _providerFactory, command);
+                default:
+                    throw new InvalidOperationException($"Provided database type is not valid!");
             }
         }
     }

--- a/Connection/DbType.cs
+++ b/Connection/DbType.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace DevHopTools.Connection
+{
+    public enum DbType
+    {
+        MSSQL,
+        MySQL
+    }
+}

--- a/Connection/MSSQL.cs
+++ b/Connection/MSSQL.cs
@@ -102,7 +102,7 @@ namespace DevHopTools.Connection
         }
 
         /// <summary>
-        /// Execute a <see cref="Command"/> to retrieve only one object from the database
+        /// Execute a <see cref="Command"/> to retrieve only one field value from the database
         /// </summary>
         /// <param name="connectionString">Complete database connection string</param>
         /// <param name="providerFactory">Valid object of type <see cref="DbProviderFactory"/></param>

--- a/Connection/MSSQL.cs
+++ b/Connection/MSSQL.cs
@@ -1,5 +1,4 @@
-﻿using MySqlConnector;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Data.Common;
@@ -7,27 +6,27 @@ using System.Text;
 
 namespace DevHopTools.Connection
 {
-    internal static class MySql
+    internal static class MSSQL
     {
         /// <summary>
-        /// Create an instance of <see cref="MySqlConnection"/> with the connection string and database provider factory
+        /// Create an instance of <see cref="DbConnection"/> with the connection string and database provider factory
         /// </summary>
         /// <param name="connectionString">Complete connection string</param>
         /// <param name="providerFactory">Valable provider factory</param>
         /// <returns>A <see cref="MySqlConnection"/> object</returns>
         /// <exception cref="ArgumentNullException"></exception>
         /// <exception cref="ArgumentException"></exception>
-        internal static MySqlConnection CreateConnection(string connectionString, DbProviderFactory providerFactory)
+        internal static DbConnection CreateConnection(string connectionString, DbProviderFactory providerFactory)
         {
             if (connectionString is null) throw new ArgumentNullException(nameof(connectionString));
             if (connectionString.Length == 0)
                 throw new ArgumentException($"{nameof(connectionString)} is not a valid connection string");
             if (providerFactory is null) throw new ArgumentNullException(nameof(providerFactory));
 
-            MySqlConnection mySqlConnection = (MySqlConnection)providerFactory.CreateConnection();
-            mySqlConnection.ConnectionString = connectionString;
+            DbConnection dbConnection = providerFactory.CreateConnection();
+            dbConnection.ConnectionString = connectionString;
 
-            return mySqlConnection;
+            return dbConnection;
         }
 
         /// <summary>
@@ -47,15 +46,15 @@ namespace DevHopTools.Connection
             if (providerFactory is null) throw new ArgumentNullException(nameof(providerFactory));
             if (command is null) throw new ArgumentNullException(nameof(command));
 
-            using (MySqlConnection mySqlConnection = CreateConnection(connectionString, providerFactory))
+            using (DbConnection dbConnection = CreateConnection(connectionString, providerFactory))
             {
-                using (MySqlCommand mySqlCommand = CreateCommand(command, mySqlConnection))
+                using (DbCommand dbCommand = CreateCommand(command, dbConnection))
                 {
-                    mySqlConnection.Open();
-                    int rows = mySqlCommand.ExecuteNonQuery();
+                    dbConnection.Open();
+                    int rows = dbCommand.ExecuteNonQuery();
 
                     if (command.IsStoredProcedure)
-                        FinalizeQuery(command, mySqlCommand);
+                        FinalizeQuery(command, dbCommand);
 
                     return rows;
                 }
@@ -83,21 +82,21 @@ namespace DevHopTools.Connection
             if (command is null) throw new ArgumentNullException(nameof(command));
             if (selector is null) throw new ArgumentNullException(nameof(selector));
 
-            using (MySqlConnection mySqlConnection = CreateConnection(connectionString, providerFactory))
+            using (DbConnection dbConnection = CreateConnection(connectionString, providerFactory))
             {
-                using (MySqlCommand mySqlCommand = CreateCommand(command, mySqlConnection))
+                using (DbCommand dbCommand = CreateCommand(command, dbConnection))
                 {
-                    mySqlConnection.Open();
-                    using (MySqlDataReader mySqlDataReader = mySqlCommand.ExecuteReader())
+                    dbConnection.Open();
+                    using (DbDataReader dataReader = dbCommand.ExecuteReader())
                     {
-                        while (mySqlDataReader.Read())
+                        while (dataReader.Read())
                         {
-                            yield return selector(mySqlDataReader);
+                            yield return selector(dataReader);
                         }
                     }
 
                     if (command.IsStoredProcedure)
-                        FinalizeQuery(command, mySqlCommand);
+                        FinalizeQuery(command, dbCommand);
                 }
             }
         }
@@ -119,15 +118,15 @@ namespace DevHopTools.Connection
             if (providerFactory is null) throw new ArgumentNullException(nameof(providerFactory));
             if (command is null) throw new ArgumentNullException(nameof(command));
 
-            using (MySqlConnection mySqlConnection = CreateConnection(connectionString, providerFactory))
+            using (DbConnection dbConnection = CreateConnection(connectionString, providerFactory))
             {
-                using (MySqlCommand mySqlCommand = CreateCommand(command, mySqlConnection))
+                using (DbCommand dbCommand = CreateCommand(command, dbConnection))
                 {
-                    mySqlConnection.Open();
-                    object result = mySqlCommand.ExecuteScalar();
+                    dbConnection.Open();
+                    object result = dbCommand.ExecuteScalar();
 
                     if (command.IsStoredProcedure)
-                        FinalizeQuery(command, mySqlCommand);
+                        FinalizeQuery(command, dbCommand);
 
                     return result is DBNull ? null : result;
                 }
@@ -152,18 +151,18 @@ namespace DevHopTools.Connection
             if (providerFactory is null) throw new ArgumentNullException(nameof(providerFactory));
             if (command is null) throw new ArgumentNullException(nameof(command));
 
-            using (MySqlConnection mySqlConnection = CreateConnection(connectionString, providerFactory))
+            using (DbConnection dbConnection = CreateConnection(connectionString, providerFactory))
             {
-                using (MySqlCommand mySqlCommand = CreateCommand(command, mySqlConnection))
+                using (DbCommand dbCommand = CreateCommand(command, dbConnection))
                 {
-                    using (MySqlDataAdapter mySqlDataAdapter = (MySqlDataAdapter)providerFactory.CreateDataAdapter())
+                    using (DbDataAdapter dbDataAdapter = providerFactory.CreateDataAdapter())
                     {
                         DataTable dataTable = new DataTable();
-                        mySqlDataAdapter.SelectCommand = mySqlCommand;
-                        mySqlDataAdapter.Fill(dataTable);
+                        dbDataAdapter.SelectCommand = dbCommand;
+                        dbDataAdapter.Fill(dataTable);
 
                         if (command.IsStoredProcedure)
-                            FinalizeQuery(command, mySqlCommand);
+                            FinalizeQuery(command, dbCommand);
 
                         return dataTable;
                     }
@@ -189,18 +188,18 @@ namespace DevHopTools.Connection
             if (providerFactory is null) throw new ArgumentNullException(nameof(providerFactory));
             if (command is null) throw new ArgumentNullException(nameof(command));
 
-            using (MySqlConnection mySqlConnection = CreateConnection(connectionString, providerFactory))
+            using (DbConnection dbConnection = CreateConnection(connectionString, providerFactory))
             {
-                using (MySqlCommand mySqlCommand = CreateCommand(command, mySqlConnection))
+                using (DbCommand dbCommand = CreateCommand(command, dbConnection))
                 {
-                    using (MySqlDataAdapter mySqlDataAdapter = (MySqlDataAdapter)providerFactory.CreateDataAdapter())
+                    using (DbDataAdapter dbDataAdapter = providerFactory.CreateDataAdapter())
                     {
                         DataSet dataSet = new DataSet();
-                        mySqlDataAdapter.SelectCommand = mySqlCommand;
-                        mySqlDataAdapter.Fill(dataSet);
+                        dbDataAdapter.SelectCommand = dbCommand;
+                        dbDataAdapter.Fill(dataSet);
 
                         if (command.IsStoredProcedure)
-                            FinalizeQuery(command, mySqlCommand);
+                            FinalizeQuery(command, dbCommand);
 
                         return dataSet;
                     }
@@ -209,54 +208,54 @@ namespace DevHopTools.Connection
         }
 
         /// <summary>
-        /// Create a <see cref="MySqlCommand"/> object from <paramref name="connection"/> object with keys 
+        /// Create a <see cref="DbCommand"/> object from <paramref name="dbConnection"/> object with keys 
         /// and values of <paramref name="command"/>
         /// </summary>
         /// <param name="command">Valid object of type <see cref="Command"/></param>
-        /// <param name="connection">A non null and valid <see cref="MySqlConnection"/> object</param>
-        /// <returns>A new instance of <see cref="MySqlCommand"/></returns>
-        private static MySqlCommand CreateCommand(Command command, MySqlConnection connection)
+        /// <param name="dbConnection">A non null and valid <see cref="DbConnection"/> object</param>
+        /// <returns>A new instance of <see cref="DbCommand"/></returns>
+        private static DbCommand CreateCommand(Command command, DbConnection dbConnection)
         {
             if (command is null) throw new ArgumentNullException(nameof(command));
-            if (connection is null) throw new ArgumentNullException(nameof(connection));
+            if (dbConnection is null) throw new ArgumentNullException(nameof(dbConnection));
 
-            MySqlCommand mySqlCommand = connection.CreateCommand();
-            mySqlCommand.CommandText = command.Query;
+            DbCommand dbCommand = dbConnection.CreateCommand();
+            dbCommand.CommandText = command.Query;
 
             if (command.IsStoredProcedure)
-                mySqlCommand.CommandType = CommandType.StoredProcedure;
+                dbCommand.CommandType = CommandType.StoredProcedure;
 
             foreach (KeyValuePair<string, Parameter> parameter in command.Parameters)
             {
-                MySqlParameter mySqlParameter = mySqlCommand.CreateParameter();
-                mySqlParameter.ParameterName = parameter.Key;
-                mySqlParameter.Value = parameter.Value.ParameterValue;
+                DbParameter dbParameter = dbCommand.CreateParameter();
+                dbParameter.ParameterName = parameter.Key;
+                dbParameter.Value = parameter.Value.ParameterValue;
 
                 if (parameter.Value.Direction == Direction.Output)
-                    mySqlParameter.Direction = ParameterDirection.Output;
+                    dbParameter.Direction = ParameterDirection.Output;
 
-                mySqlCommand.Parameters.Add(mySqlParameter);
+                dbCommand.Parameters.Add(dbParameter);
             }
 
-            return mySqlCommand;
+            return dbCommand;
         }
 
         /// <summary>
-        /// Finalize the <paramref name="mySqlCommand"/> object's Parameters value if <see cref="Direction"/> is 
+        /// Finalize the <paramref name="dbCommand"/> object's Parameters value if <see cref="Direction"/> is 
         /// <see cref="Direction.Output"/>
         /// </summary>
         /// <param name="command">Valid object of type <see cref="Command"/></param>
-        /// <param name="mySqlCommand">A valid, not null <see cref="MySqlCommand"/> object</param>
-        private static void FinalizeQuery(Command command, MySqlCommand mySqlCommand)
+        /// <param name="dbCommand">A valid, not null <see cref="DbCommand"/> object</param>
+        private static void FinalizeQuery(Command command, DbCommand dbCommand)
         {
             if (command is null) throw new ArgumentNullException(nameof(command));
-            if (mySqlCommand is null) throw new ArgumentNullException(nameof(mySqlCommand));
+            if (dbCommand is null) throw new ArgumentNullException(nameof(dbCommand));
 
             foreach (KeyValuePair<string, Parameter> parameter in command.Parameters)
             {
                 if (parameter.Value.Direction == Direction.Output)
                 {
-                    parameter.Value.ParameterValue = mySqlCommand.Parameters[parameter.Key].Value;
+                    parameter.Value.ParameterValue = dbCommand.Parameters[parameter.Key].Value;
                 }
             }
         }

--- a/Connection/MySql.cs
+++ b/Connection/MySql.cs
@@ -1,0 +1,258 @@
+﻿using MySqlConnector;
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Data.Common;
+using System.Text;
+
+namespace DevHopTools.Connection
+{
+    internal static class MySql
+    {
+        /// <summary>
+        /// Create an instance of MySqlConnection with the connection string and database provider factory
+        /// </summary>
+        /// <param name="connectionString">Complete connection string</param>
+        /// <param name="providerFactory">Valable provider factory</param>
+        /// <returns>A <see cref="MySqlConnection"/> object</returns>
+        /// <exception cref="ArgumentNullException"></exception>
+        /// <exception cref="ArgumentException"></exception>
+        internal static MySqlConnection CreateConnection(string connectionString, DbProviderFactory providerFactory)
+        {
+            if (connectionString is null) throw new ArgumentNullException(nameof(connectionString));
+            if (connectionString.Length == 0)
+                throw new ArgumentException($"{nameof(connectionString)} is not a valid connection string");
+            if (providerFactory is null) throw new ArgumentNullException(nameof(providerFactory));
+
+            MySqlConnection mySqlConnection = (MySqlConnection)providerFactory.CreateConnection();
+            mySqlConnection.ConnectionString = connectionString;
+
+            return mySqlConnection;
+        }
+
+        /// <summary>
+        /// Execute a query and returns the number of row affected
+        /// </summary>
+        /// <param name="connectionString">Complete database connection string</param>
+        /// <param name="providerFactory">Valid object of type <see cref="DbProviderFactory"/></param>
+        /// <param name="command">Valid object of type <see cref="Command"/></param>
+        /// <returns>The number of row affected</returns>
+        /// <exception cref="ArgumentNullException"></exception>
+        /// <exception cref="ArgumentException"></exception>
+        internal static int ExecuteNonQuery(string connectionString, DbProviderFactory providerFactory, Command command)
+        {
+            if (connectionString is null) throw new ArgumentNullException(nameof(connectionString));
+            if (connectionString.Length == 0)
+                throw new ArgumentException($"{nameof(connectionString)} is not a valid connection string");
+            if (providerFactory is null) throw new ArgumentNullException(nameof(providerFactory));
+            if (command is null) throw new ArgumentNullException(nameof(command));
+
+            using (MySqlConnection mySqlConnection = CreateConnection(connectionString, providerFactory))
+            {
+                using (MySqlCommand mySqlCommand = CreateCommand(command, mySqlConnection))
+                {
+                    mySqlConnection.Open();
+                    int rows = mySqlCommand.ExecuteNonQuery();
+
+                    if (command.IsStoredProcedure)
+                        FinalizeQuery(command, mySqlCommand);
+
+                    return rows;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Execute <see cref="Command"/>, retrieve selected data from the database and map it through <paramref name="selector"/>
+        /// </summary>
+        /// <typeparam name="TResult">Return object type</typeparam>
+        /// <param name="connectionString">Complete database connection string</param>
+        /// <param name="providerFactory">Valid object of type <see cref="DbProviderFactory"/></param>
+        /// <param name="command">Valid object of type <see cref="Command"/></param>
+        /// <param name="selector">Mapping function to turn a <see cref="IDataRecord"/> to <typeparamref name="TResult"/></param>
+        /// <returns>A <see cref="IEnumerable{T}"/> with <c>T</c> being of type <typeparamref name="TResult"/></returns>
+        /// <exception cref="ArgumentNullException"></exception>
+        /// <exception cref="ArgumentException"></exception>
+        internal static IEnumerable<TResult> ExecuteReader<TResult>(string connectionString, DbProviderFactory providerFactory,
+            Command command, Func<IDataRecord, TResult> selector)
+        {
+            if (connectionString is null) throw new ArgumentNullException(nameof(connectionString));
+            if (connectionString.Length == 0)
+                throw new ArgumentException($"{nameof(connectionString)} is not a valid connection string");
+            if (providerFactory is null) throw new ArgumentNullException(nameof(providerFactory));
+            if (command is null) throw new ArgumentNullException(nameof(command));
+            if (selector is null) throw new ArgumentNullException(nameof(selector));
+
+            using (MySqlConnection mySqlConnection = CreateConnection(connectionString, providerFactory))
+            {
+                using (MySqlCommand mySqlCommand = CreateCommand(command, mySqlConnection))
+                {
+                    mySqlConnection.Open();
+                    using (MySqlDataReader mySqlDataReader = mySqlCommand.ExecuteReader())
+                    {
+                        while (mySqlDataReader.Read())
+                        {
+                            yield return selector(mySqlDataReader);
+                        }
+                    }
+
+                    if (command.IsStoredProcedure)
+                        FinalizeQuery(command, mySqlCommand);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Execute a <see cref="Command"/> to retrieve only one object from the database
+        /// </summary>
+        /// <param name="connectionString">Complete database connection string</param>
+        /// <param name="providerFactory">Valid object of type <see cref="DbProviderFactory"/></param>
+        /// <param name="command">Valid object of type <see cref="Command"/></param>
+        /// <returns>A castable object</returns>
+        /// <exception cref="ArgumentNullException"></exception>
+        /// <exception cref="ArgumentException"></exception>
+        internal static object ExecuteScalar(string connectionString, DbProviderFactory providerFactory, Command command)
+        {
+            if (connectionString is null) throw new ArgumentNullException(nameof(connectionString));
+            if (connectionString.Length == 0)
+                throw new ArgumentException($"{nameof(connectionString)} is not a valid connection string");
+            if (providerFactory is null) throw new ArgumentNullException(nameof(providerFactory));
+            if (command is null) throw new ArgumentNullException(nameof(command));
+
+            using (MySqlConnection mySqlConnection = CreateConnection(connectionString, providerFactory))
+            {
+                using (MySqlCommand mySqlCommand = CreateCommand(command, mySqlConnection))
+                {
+                    mySqlConnection.Open();
+                    object result = mySqlCommand.ExecuteScalar();
+
+                    if (command.IsStoredProcedure)
+                        FinalizeQuery(command, mySqlCommand);
+
+                    return result is DBNull ? null : result;
+                }
+            }
+        }
+
+        // TODO : Write a complete comment
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="connectionString">Complete database connection string</param>
+        /// <param name="providerFactory">Valid object of type <see cref="DbProviderFactory"/></param>
+        /// <param name="command">Valid object of type <see cref="Command"/></param>
+        /// <returns></returns>
+        /// <exception cref="ArgumentNullException"></exception>
+        /// <exception cref="ArgumentException"></exception>
+        internal static DataTable GetDataTable(string connectionString, DbProviderFactory providerFactory, Command command)
+        {
+            if (connectionString is null) throw new ArgumentNullException(nameof(connectionString));
+            if (connectionString.Length == 0)
+                throw new ArgumentException($"{nameof(connectionString)} is not a valid connection string");
+            if (providerFactory is null) throw new ArgumentNullException(nameof(providerFactory));
+            if (command is null) throw new ArgumentNullException(nameof(command));
+
+            using (MySqlConnection mySqlConnection = CreateConnection(connectionString, providerFactory))
+            {
+                using (MySqlCommand mySqlCommand = CreateCommand(command, mySqlConnection))
+                {
+                    using (MySqlDataAdapter mySqlDataAdapter = (MySqlDataAdapter)providerFactory.CreateDataAdapter())
+                    {
+                        DataTable dataTable = new DataTable();
+                        mySqlDataAdapter.SelectCommand = mySqlCommand;
+                        mySqlDataAdapter.Fill(dataTable);
+
+                        if (command.IsStoredProcedure)
+                            FinalizeQuery(command, mySqlCommand);
+
+                        return dataTable;
+                    }
+                }
+            }
+        }
+
+        // TODO : Write a complete comment
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="connectionString">Complete database connection string</param>
+        /// <param name="providerFactory">Valid object of type <see cref="DbProviderFactory"/></param>
+        /// <param name="command">Valid object of type <see cref="Command"/></param>
+        /// <returns></returns>
+        /// <exception cref="ArgumentNullException"></exception>
+        /// <exception cref="ArgumentException"></exception>
+        internal static DataSet GetDataSet(string connectionString, DbProviderFactory providerFactory, Command command)
+        {
+            if (connectionString is null) throw new ArgumentNullException(nameof(connectionString));
+            if (connectionString.Length == 0)
+                throw new ArgumentException($"{nameof(connectionString)} is not a valid connection string");
+            if (providerFactory is null) throw new ArgumentNullException(nameof(providerFactory));
+            if (command is null) throw new ArgumentNullException(nameof(command));
+
+            using (MySqlConnection mySqlConnection = CreateConnection(connectionString, providerFactory))
+            {
+                using (MySqlCommand mySqlCommand = CreateCommand(command, mySqlConnection))
+                {
+                    using (MySqlDataAdapter mySqlDataAdapter = (MySqlDataAdapter)providerFactory.CreateDataAdapter())
+                    {
+                        DataSet dataSet = new DataSet();
+                        mySqlDataAdapter.SelectCommand = mySqlCommand;
+                        mySqlDataAdapter.Fill(dataSet);
+
+                        if (command.IsStoredProcedure)
+                            FinalizeQuery(command, mySqlCommand);
+
+                        return dataSet;
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Create a <see cref="MySqlCommand"/> object from <paramref name="connection"/> object with keys 
+        /// and values of <paramref name="command"/>
+        /// </summary>
+        /// <param name="command">Valid object of type <see cref="Command"/></param>
+        /// <param name="connection">A non null and valid <see cref="MySqlConnection"/> object</param>
+        /// <returns>A new instance of <see cref="MySqlCommand"/></returns>
+        private static MySqlCommand CreateCommand(Command command, MySqlConnection connection)
+        {
+            MySqlCommand mySqlCommand = connection.CreateCommand();
+            mySqlCommand.CommandText = command.Query;
+
+            if (command.IsStoredProcedure)
+                mySqlCommand.CommandType = CommandType.StoredProcedure;
+
+            foreach (KeyValuePair<string, Parameter> parameter in command.Parameters)
+            {
+                MySqlParameter mySqlParameter = mySqlCommand.CreateParameter();
+                mySqlParameter.ParameterName = parameter.Key;
+                mySqlParameter.Value = parameter.Value.ParameterValue;
+
+                if (parameter.Value.Direction == Direction.Output)
+                    mySqlParameter.Direction = ParameterDirection.Output;
+
+                mySqlCommand.Parameters.Add(mySqlParameter);
+            }
+
+            return mySqlCommand;
+        }
+
+        /// <summary>
+        /// Finalize the <paramref name="mySqlCommand"/> object's Parameters value if <see cref="Direction"/> is 
+        /// <see cref="Direction.Output"/>
+        /// </summary>
+        /// <param name="command">Valid object of type <see cref="Command"/></param>
+        /// <param name="mySqlCommand">A valid, not null <see cref="MySqlCommand"/> object</param>
+        private static void FinalizeQuery(Command command, MySqlCommand mySqlCommand)
+        {
+            foreach (KeyValuePair<string, Parameter> parameter in command.Parameters)
+            {
+                if (parameter.Value.Direction == Direction.Output)
+                {
+                    parameter.Value.ParameterValue = mySqlCommand.Parameters[parameter.Key].Value;
+                }
+            }
+        }
+    }
+}

--- a/Connection/MySql.cs
+++ b/Connection/MySql.cs
@@ -103,7 +103,7 @@ namespace DevHopTools.Connection
         }
 
         /// <summary>
-        /// Execute a <see cref="Command"/> to retrieve only one object from the database
+        /// Execute a <see cref="Command"/> to retrieve only one fied value from the database
         /// </summary>
         /// <param name="connectionString">Complete database connection string</param>
         /// <param name="providerFactory">Valid object of type <see cref="DbProviderFactory"/></param>

--- a/DevHopTools.csproj
+++ b/DevHopTools.csproj
@@ -19,7 +19,8 @@
 	<ItemGroup>
 		<PackageReference Include="Dapper" Version="2.0.123" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
+		<PackageReference Include="MySqlConnector" Version="2.1.8" />
 		<PackageReference Include="System.Data.SqlClient" Version="4.8.3" />
 	</ItemGroup>
 

--- a/DevHopTools.csproj
+++ b/DevHopTools.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>netstandard2.0</TargetFramework>
+		<TargetFramework>netstandard2.1</TargetFramework>
 		<PackageId>DevHopTools</PackageId>
 		<Version>1.0.0</Version>
 		<Copyright>DevHop@2022</Copyright>

--- a/DevHopTools.sln
+++ b/DevHopTools.sln
@@ -3,7 +3,9 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.0.31919.166
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DevHopTools", "DevHopTools.csproj", "{DB45226D-00D2-46C2-BE97-3BFB5E860A38}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DevHopTools", "DevHopTools.csproj", "{DB45226D-00D2-46C2-BE97-3BFB5E860A38}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DevHopTools.UnitTest", "..\DevHopTools.UnitTest\DevHopTools.UnitTest.csproj", "{9D857427-84EB-4E8B-AB25-B5DDE6740AD8}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -15,6 +17,10 @@ Global
 		{DB45226D-00D2-46C2-BE97-3BFB5E860A38}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{DB45226D-00D2-46C2-BE97-3BFB5E860A38}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{DB45226D-00D2-46C2-BE97-3BFB5E860A38}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9D857427-84EB-4E8B-AB25-B5DDE6740AD8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9D857427-84EB-4E8B-AB25-B5DDE6740AD8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9D857427-84EB-4E8B-AB25-B5DDE6740AD8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9D857427-84EB-4E8B-AB25-B5DDE6740AD8}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/DevHopTools.sln
+++ b/DevHopTools.sln
@@ -5,8 +5,6 @@ VisualStudioVersion = 17.0.31919.166
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DevHopTools", "DevHopTools.csproj", "{DB45226D-00D2-46C2-BE97-3BFB5E860A38}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DevHopTools.UnitTest", "..\DevHopTools.UnitTest\DevHopTools.UnitTest.csproj", "{9D857427-84EB-4E8B-AB25-B5DDE6740AD8}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -17,10 +15,6 @@ Global
 		{DB45226D-00D2-46C2-BE97-3BFB5E860A38}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{DB45226D-00D2-46C2-BE97-3BFB5E860A38}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{DB45226D-00D2-46C2-BE97-3BFB5E860A38}.Release|Any CPU.Build.0 = Release|Any CPU
-		{9D857427-84EB-4E8B-AB25-B5DDE6740AD8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{9D857427-84EB-4E8B-AB25-B5DDE6740AD8}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{9D857427-84EB-4E8B-AB25-B5DDE6740AD8}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{9D857427-84EB-4E8B-AB25-B5DDE6740AD8}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
# Summary

## Description

Connection library now works both with Microsoft SQL Server and MySql databases and derived ones (MariaDb). The modifications have been tested through Unit Testing for MySql with basic crud and stored procedures.

## Details

The project is now composed of different static classes that execute the different functions like ExecuteScalar, ExecuteReader based on the database type declared in `public Connection(string connectionString, DbProviderFactory providerFactory, DbType dbType)` instanciation by an enumeration `DbType`.

Every public methods of `Connection` class are just composed of a switch case that redirect to the right static function based on database type

### Example

#### Method `ExecuteReader(...)` in `Connection`
```csharp
/// <summary>
/// Execute a query and retrieve selected fields values from the database
/// </summary>
/// <typeparam name="TResult">The type of the object with want to retrieve</typeparam>
/// <param name="command">The SQL Command</param>
/// <param name="selector">Callback function to map the values from database to the desired type</param>
/// <returns>A <see cref="IEnumerable{T}"/> of type <typeparamref name="TResult"/></returns>
public IEnumerable<TResult> ExecuteReader<TResult>(Command command, Func<IDataRecord, TResult> selector)
{
    switch (_dbType)
    {
        case DbType.MSSQL: return MSSQL.ExecuteReader(_connectionString, _providerFactory, command, selector);
        case DbType.MySQL: return MySql.ExecuteReader(_connectionString, _providerFactory, command, selector);
        default:
            throw new InvalidOperationException($"Provided database type is not valid!");
    }
}
```

#### `ExecuteReader(...)` from `MySql` static class

```csharp
/// <summary>
/// Execute <see cref="Command"/>, retrieve selected data from the database and map it through <paramref name="selector"/>
/// </summary>
/// <typeparam name="TResult">Return object type</typeparam>
/// <param name="connectionString">Complete database connection string</param>
/// <param name="providerFactory">Valid object of type <see cref="DbProviderFactory"/></param>
/// <param name="command">Valid object of type <see cref="Command"/></param>
/// <param name="selector">Mapping function to turn a <see cref="IDataRecord"/> to <typeparamref name="TResult"/></param>
/// <returns>A <see cref="IEnumerable{T}"/> with <c>T</c> being of type <typeparamref name="TResult"/></returns>
/// <exception cref="ArgumentNullException"></exception>
/// <exception cref="ArgumentException"></exception>
internal static IEnumerable<TResult> ExecuteReader<TResult>(string connectionString, DbProviderFactory providerFactory,
    Command command, Func<IDataRecord, TResult> selector)
{
    if (connectionString is null) throw new ArgumentNullException(nameof(connectionString));
    if (connectionString.Length == 0)
        throw new ArgumentException($"{nameof(connectionString)} is not a valid connection string");
    if (providerFactory is null) throw new ArgumentNullException(nameof(providerFactory));
    if (command is null) throw new ArgumentNullException(nameof(command));
    if (selector is null) throw new ArgumentNullException(nameof(selector));

    using (MySqlConnection mySqlConnection = CreateConnection(connectionString, providerFactory))
    {
        using (MySqlCommand mySqlCommand = CreateCommand(command, mySqlConnection))
        {
            mySqlConnection.Open();
            using (MySqlDataReader mySqlDataReader = mySqlCommand.ExecuteReader())
            {
                while (mySqlDataReader.Read())
                {
                    yield return selector(mySqlDataReader);
                }
            }

            if (command.IsStoredProcedure)
                FinalizeQuery(command, mySqlCommand);
        }
    }
}
```